### PR TITLE
fix(#526): 添加覆盖物 同时创建 createXAxisFigures和createPointFigures 只会会渲染一个覆盖物

### DIFF
--- a/src/store/OverlayStore.ts
+++ b/src/store/OverlayStore.ts
@@ -241,8 +241,9 @@ export default class OverlayStore {
     })
     if (ids.some(id => id !== null)) {
       this._sort()
-      this._chartStore.getChart().updatePane(UpdateLevel.Overlay, paneId)
-      this._chartStore.getChart().updatePane(UpdateLevel.Overlay, PaneIdConstants.X_AXIS)
+      const chart = this._chartStore.getChart()
+      chart.updatePane(UpdateLevel.Overlay, paneId)
+      chart.updatePane(UpdateLevel.Overlay, PaneIdConstants.X_AXIS)
     }
     return ids
   }

--- a/src/store/OverlayStore.ts
+++ b/src/store/OverlayStore.ts
@@ -242,6 +242,7 @@ export default class OverlayStore {
     if (ids.some(id => id !== null)) {
       this._sort()
       this._chartStore.getChart().updatePane(UpdateLevel.Overlay, paneId)
+      this._chartStore.getChart().updatePane(UpdateLevel.Overlay, PaneIdConstants.X_AXIS)
     }
     return ids
   }


### PR DESCRIPTION
修复：[#526](https://github.com/klinecharts/KLineChart/issues/526)