### PR TITLE
解决正在画线覆盖物，被删除的问题

### DIFF
--- a/src/Store.ts
+++ b/src/Store.ts
@@ -1187,7 +1187,7 @@ export default class StoreImp implements Store {
       })
     }
     const progressOverlay = this._progressOverlayInfo?.overlay
-    if (isValid(progressOverlay)) {
+    if (isValid(progressOverlay) && find([progressOverlay]).length > 0) {
       const paneOverlays = map.get(progressOverlay.paneId) ?? []
       paneOverlays.push(progressOverlay)
       map.set(progressOverlay.paneId, paneOverlays)


### PR DESCRIPTION
这里添加判断，如果删除的过滤条件在正在画线中，才进行删除，否则不删除