### PR TITLE
feat: update IndicatorTooltipView to Added feature event ability to return indicatorId

### DIFF
--- a/src/Store.ts
+++ b/src/Store.ts
@@ -67,6 +67,7 @@ const enum ScrollLimitRole {
 export interface TooltipIcon {
   paneId: string
   indicatorName: string
+  indicatorId: string
   iconId: string
 }
 

--- a/src/view/CandleTooltipView.ts
+++ b/src/view/CandleTooltipView.ts
@@ -106,12 +106,12 @@ export default class CandleTooltipView extends IndicatorTooltipView {
 
       prevRowHeight = this.drawStandardTooltipIcons(
         ctx, leftIcons, coordinate,
-        '', left, prevRowHeight, maxWidth
+        '', '', left, prevRowHeight, maxWidth
       )
 
       prevRowHeight = this.drawStandardTooltipIcons(
         ctx, middleIcons, coordinate,
-        '', left, prevRowHeight, maxWidth
+        '', '', left, prevRowHeight, maxWidth
       )
 
       if (legends.length > 0) {
@@ -123,7 +123,7 @@ export default class CandleTooltipView extends IndicatorTooltipView {
 
       prevRowHeight = this.drawStandardTooltipIcons(
         ctx, rightIcons, coordinate,
-        '', left, prevRowHeight, maxWidth
+        '', '', left, prevRowHeight, maxWidth
       )
     }
     return coordinate.y + prevRowHeight

--- a/src/view/IndicatorTooltipView.ts
+++ b/src/view/IndicatorTooltipView.ts
@@ -79,7 +79,7 @@ export default class IndicatorTooltipView extends View<YAxis> {
           const [leftIcons, middleIcons, rightIcons] = this.classifyTooltipIcons(icons)
           prevRowHeight = this.drawStandardTooltipIcons(
             ctx, leftIcons,
-            coordinate, indicator.name,
+            coordinate, indicator.name, indicator.id,
             left, prevRowHeight, maxWidth
           )
 
@@ -102,7 +102,7 @@ export default class IndicatorTooltipView extends View<YAxis> {
 
           prevRowHeight = this.drawStandardTooltipIcons(
             ctx, middleIcons,
-            coordinate, indicator.name,
+            coordinate, indicator.name, indicator.id,
             left, prevRowHeight, maxWidth
           )
 
@@ -116,7 +116,7 @@ export default class IndicatorTooltipView extends View<YAxis> {
           // draw right icons
           prevRowHeight = this.drawStandardTooltipIcons(
             ctx, rightIcons,
-            coordinate, indicator.name,
+            coordinate, indicator.name, indicator.id,
             left, prevRowHeight, maxWidth
           )
           top = coordinate.y + prevRowHeight
@@ -131,6 +131,7 @@ export default class IndicatorTooltipView extends View<YAxis> {
     icons: TooltipIconStyle[],
     coordinate: Coordinate,
     indicatorName: string,
+    indicatorId: string,
     left: number,
     prevRowHeight: number,
     maxWidth: number
@@ -181,8 +182,8 @@ export default class IndicatorTooltipView extends View<YAxis> {
             backgroundColor: active ? activeBackgroundColor : backgroundColor
           }
         }, {
-          mouseClickEvent: this._boundIconClickEvent({ paneId, indicatorName, iconId: icon.id }),
-          mouseMoveEvent: this._boundIconMouseMoveEvent({ paneId, indicatorName, iconId: icon.id })
+          mouseClickEvent: this._boundIconClickEvent({ paneId, indicatorName, indicatorId, iconId: icon.id }),
+          mouseMoveEvent: this._boundIconMouseMoveEvent({ paneId, indicatorName, indicatorId, iconId: icon.id })
         })?.draw(ctx)
         coordinate.x += (marginLeft + paddingLeft + ctx.measureText(text).width + paddingRight + marginRight)
       })


### PR DESCRIPTION
all icon events return in "ClickEvent" icon only return data like this {paneId,indicatorName,iconId} 
the problem is if two indicators have the same name the change of "visible" or "calcParams" changes all two indicators because "overrideIndicator" uses only data returned by event {paneId,indicatorName,iconId} 

Added feature event ability to return indicatorId.