### PR TITLE
fix: reset layout pending flag when layout throws

### DIFF
--- a/src/Chart.ts
+++ b/src/Chart.ts
@@ -267,8 +267,11 @@ export default class ChartImp implements Chart {
       this._layoutPending = true
       Promise.resolve()
         .then((_) => {
-          this._layout()
-          this._layoutPending = false
+          try {
+            this._layout()
+          } finally {
+            this._layoutPending = false
+          }
         })
         .catch((_: unknown) => {
           // todo


### PR DESCRIPTION
## Problem

`ChartImp.layout()` guards re-entry with `_layoutPending`, but the reset is the statement **after** the `this._layout()` call inside the `.then` handler:

```ts
if (!this._layoutPending) {
  this._layoutPending = true
  Promise.resolve()
    .then((_) => {
      this._layout()
      this._layoutPending = false   // ← skipped when _layout() throws
    })
    .catch((_: unknown) => {
      // todo                       // ← error swallowed, nothing logged
    })
}
```

If `_layout()` throws, the flag stays `true` **forever** (this is the only reset — `src/Chart.ts:271`), the rejection is swallowed by the empty `catch`, and every subsequent `layout()` call returns immediately. Layout-driven updates — scroll, zoom, data updates, resize, `setStyles`, indicator overrides — permanently stop, with no console output. The rendered frame stays on screen, so the chart looks alive but no longer reacts.

A reachable trigger: `_layout()` ends in `updatePane(UpdateLevel.All)` → `OverlayView._drawOverlay` → `getFigures` → the overlay's `createPointFigures` callback (`src/view/OverlayView.ts:525, 574`) — invoked without isolation. One throw from a user overlay template (e.g. an overlay restored from persisted state with missing or invalid points) freezes the whole chart.

## Fix

Reset the flag in a `finally` block:

```diff
        .then((_) => {
-          this._layout()
-          this._layoutPending = false
+          try {
+            this._layout()
+          } finally {
+            this._layoutPending = false
+          }
        })
```

Behaviour on success is unchanged. On throw, the pending flag is released, so the next `layout()` call runs again. The throwing callback itself still needs fixing by its author, but one bad callback no longer bricks the layout pipeline.

## Verification

- `pnpm code-lint` — pass (154 files, no fixes)
- `pnpm type-check` — pass
- `pnpm build-esm` — pass
- Manual repro on `main`: register a custom overlay whose `createPointFigures` throws, then call any layout-triggering API — scroll / zoom / data updates stop responding; with this patch they keep working.

## Notes

- The error is still swallowed by the existing empty `catch` (unchanged); surfacing it might be worth a separate change.
- Isolating user callbacks in the overlay draw path is a related but separate fix, intentionally not mixed in.
- Coalescing layouts to one per animation frame is a separate performance topic.