### PR TITLE
fix: isolate user overlay callbacks in draw path

### DIFF
--- a/src/view/OverlayView.ts
+++ b/src/view/OverlayView.ts
@@ -571,7 +571,11 @@ export default class OverlayView<C extends Axis = YAxis> extends View<C> {
     const yAxis = pane.getYAxisComponentById() as unknown as Nullable<YAxis>
     const xAxis = chart.getXAxisPane().getXAxisComponent()
     const bounding = widget.getBounding()
-    return o.createPointFigures?.({ chart, overlay: o, coordinates, bounding, xAxis, yAxis }) ?? []
+    try {
+      return o.createPointFigures?.({ chart, overlay: o, coordinates, bounding, xAxis, yAxis }) ?? []
+    } catch {
+      return []
+    }
   }
 
   protected drawDefaultFigures(ctx: CanvasRenderingContext2D, overlay: OverlayImp, coordinates: Coordinate[]): void {

--- a/src/view/OverlayXAxisView.ts
+++ b/src/view/OverlayXAxisView.ts
@@ -72,6 +72,10 @@ export default class OverlayXAxisView extends OverlayYAxisView<XAxis> {
     const yAxis = pane.getYAxisComponentById() as unknown as Nullable<YAxis>
     const xAxis = chart.getXAxisPane().getXAxisComponent()
     const bounding = widget.getBounding()
-    return o.createXAxisFigures?.({ chart, overlay: o, coordinates, bounding, xAxis, yAxis }) ?? []
+    try {
+      return o.createXAxisFigures?.({ chart, overlay: o, coordinates, bounding, xAxis, yAxis }) ?? []
+    } catch {
+      return []
+    }
   }
 }

--- a/src/view/OverlayYAxisView.ts
+++ b/src/view/OverlayYAxisView.ts
@@ -80,6 +80,10 @@ export default class OverlayYAxisView<C extends Axis = YAxis> extends OverlayVie
     const yAxis = pane.getYAxisComponentById() as unknown as Nullable<YAxis>
     const xAxis = chart.getXAxisPane().getXAxisComponent()
     const bounding = widget.getBounding()
-    return overlay.createYAxisFigures?.({ chart, overlay, coordinates, bounding, xAxis, yAxis }) ?? []
+    try {
+      return overlay.createYAxisFigures?.({ chart, overlay, coordinates, bounding, xAxis, yAxis }) ?? []
+    } catch {
+      return []
+    }
   }
 }


### PR DESCRIPTION
## Problem

The three overlay figure callbacks — `createPointFigures`, `createXAxisFigures`,
`createYAxisFigures` — are user-supplied code (custom overlay templates). They are
invoked during drawing with no isolation:

```ts
// src/view/OverlayView.ts:574
return o.createPointFigures?.({ chart, overlay: o, coordinates, bounding, xAxis, yAxis }) ?? []
// src/view/OverlayXAxisView.ts:75 / src/view/OverlayYAxisView.ts:83 — same shape
```

If the callback throws, the exception propagates up through `_drawOverlay` →
`updatePane` → `_layout`, breaking the whole draw pass. A realistic case: overlays
restored from persisted state (local storage / cloud) can end up with an invalid
point set, and a custom template that assumes valid input throws
(`TypeError: Cannot read properties of undefined (reading 'length')` at
`createPointFigures`). One broken overlay then breaks drawing for the chart, and —
combined with the layout pending flag not being released on throw — freezes it entirely.

Indicator callbacks already have this isolation: `IndicatorImp.calcImp`
(`src/component/Indicator.ts`) wraps the user `calc` callback in `try { … } catch { … }`,
so a broken indicator fails alone instead of breaking the chart. The overlay
callbacks deserve the same treatment.

## Fix

Wrap each of the three invocations and fall back to an empty figure list:

```diff
-    return o.createPointFigures?.({ chart, overlay: o, coordinates, bounding, xAxis, yAxis }) ?? []
+    try {
+      return o.createPointFigures?.({ chart, overlay: o, coordinates, bounding, xAxis, yAxis }) ?? []
+    } catch {
+      return []
+    }
```

Same for `createXAxisFigures` (`OverlayXAxisView`) and `createYAxisFigures`
(`OverlayYAxisView`). A throwing overlay now simply draws nothing for that pass
instead of breaking the draw pipeline — mirroring the `calcImp` behaviour for indicators.

## Verification

- `pnpm code-lint` — pass (154 files, no fixes)
- `pnpm type-check` — pass
- `pnpm build-esm` — pass
- Manual repro on `main`: `registerOverlay` a template whose `createPointFigures`
  throws, create one, trigger a redraw — drawing breaks; with this patch the rest
  of the chart keeps drawing correctly and the overlay is skipped.

## Notes

- The catch is intentionally silent, matching the existing `calcImp` isolation
  style. Logging the error could be added separately if wanted.
- Companion fix: releasing `_layoutPending` when `_layout()` throws (#832) —
  each addresses one half of the "one bad overlay freezes the chart" failure.