### PR TITLE
fix: reset gesture state on touchcancel

### DIFF
--- a/src/Event.ts
+++ b/src/Event.ts
@@ -649,6 +649,26 @@ export default class Event implements EventHandler {
     return false
   }
 
+  touchCancelEvent(e: MouseTouchEvent): boolean {
+    const { widget } = this._findWidgetByEvent(e)
+    if (widget !== null) {
+      const event = this._makeWidgetEvent(e, widget)
+      // notify the widget the gesture is over, same as a touch end
+      widget.dispatchEvent('mouseUpEvent', event)
+    }
+    this._startScrollCoordinate = null
+    this._prevYAxisRanges.clear()
+    this._xAxisStartScaleCoordinate = null
+    this._xAxisStartScaleDistance = 0
+    this._xAxisScale = 1
+    this._yAxisStartScaleDistance = 0
+    this._touchCoordinate = null
+    this._touchCancelCrosshair = false
+    this._touchZoomed = false
+    this._chart.getChartStore().setCrosshair()
+    return true
+  }
+
   tapEvent(e: MouseTouchEvent): boolean {
     const { pane, widget } = this._findWidgetByEvent(e)
     let consumed = false

--- a/src/common/EventHandler.ts
+++ b/src/common/EventHandler.ts
@@ -56,6 +56,7 @@ export interface EventHandler {
 
   mouseUpEvent?: MouseTouchEventCallback
   touchEndEvent?: MouseTouchEventCallback
+  touchCancelEvent?: MouseTouchEventCallback
 
   mouseDownOutsideEvent?: MouseTouchEventCallback
 
@@ -514,6 +515,26 @@ export default class EventHandlerImp {
     }
   }
 
+  private _touchCancelHandler(touchCancelEvent: TouchEvent): void {
+    const touch = this._touchWithId(touchCancelEvent.changedTouches, this._activeTouchId)
+    this._activeTouchId = null
+    this._lastTouchEventTimeStamp = this._eventTimeStamp(touchCancelEvent)
+    this._clearLongTapTimeout()
+    this._touchMoveStartCoordinate = null
+    // a cancelled gesture must not resolve into a tap
+    this._cancelTap = true
+    this._resetTapTimeout()
+
+    if (this._unsubscribeRootTouchEvents !== null) {
+      this._unsubscribeRootTouchEvents()
+      this._unsubscribeRootTouchEvents = null
+    }
+
+    if (touch !== null) {
+      this._processEvent(this._makeCompatEvent(touchCancelEvent, touch), this._handler.touchCancelEvent)
+    }
+  }
+
   private _mouseUpHandler(mouseUpEvent: MouseEvent): void {
     if (mouseUpEvent.button !== MouseEventButton.Left) {
       return
@@ -589,14 +610,17 @@ export default class EventHandlerImp {
     {
       const boundTouchMoveWithDownHandler = this._touchMoveHandler.bind(this)
       const boundTouchEndHandler = this._touchEndHandler.bind(this)
+      const boundTouchCancelHandler = this._touchCancelHandler.bind(this)
 
       this._unsubscribeRootTouchEvents = () => {
         rootElement.removeEventListener('touchmove', boundTouchMoveWithDownHandler)
         rootElement.removeEventListener('touchend', boundTouchEndHandler)
+        rootElement.removeEventListener('touchcancel', boundTouchCancelHandler)
       }
 
       rootElement.addEventListener('touchmove', boundTouchMoveWithDownHandler, { passive: false })
       rootElement.addEventListener('touchend', boundTouchEndHandler, { passive: false })
+      rootElement.addEventListener('touchcancel', boundTouchCancelHandler, { passive: false })
 
       this._clearLongTapTimeout()
       this._longTapTimeoutId = setTimeout(this._longTapHandler.bind(this, downEvent), Delay.LongTap)


### PR DESCRIPTION
## Problem

When the system cancels an in-progress touch gesture (incoming call overlay, notification
shade, palm rejection, browser gesture takeover), a `touchcancel` event is fired instead of
`touchend`. Currently it is almost unhandled:

- `src/common/EventHandler.ts:692` — a `touchcancel` listener on the target only clears the
  long-tap timeout.
- The root-level `touchmove`/`touchend` listeners (subscribed on touch start, unsubscribed
  on touch end) are **not** removed on cancel.
- Gesture state (`_activeTouchId`, `_touchMoveStartCoordinate`) is not reset, and the chart
  level (`Event`) never learns the gesture is over.

After a cancelled gesture the handler stays in the "finger down" state: the next touch has
to untangle stale listeners/state, and dragging/scrolling state started on the chart
(`_startScrollCoordinate`, axis scale state, crosshair) is left dangling — the chart can
keep behaving as if the finger is still down.

## Fix

Handle `touchcancel` symmetrically to `touchend`:

**`src/common/EventHandler.ts`**
- Add `touchCancelEvent` to the `EventHandler` interface.
- Add `_touchCancelHandler`: resolves the active touch, resets `_activeTouchId`,
  `_lastTouchEventTimeStamp`, `_touchMoveStartCoordinate`, unsubscribes the root touch
  listeners, marks the gesture so it cannot resolve into a tap, and dispatches
  `touchCancelEvent`.
- Subscribe/unsubscribe `touchcancel` together with `touchmove`/`touchend` on the root
  element (`{ passive: false }`).

**`src/Event.ts`**
- Add `touchCancelEvent(e)`: sends `mouseUpEvent` to the widget under the finger (so
  widgets that started a pressed interaction release it), then unconditionally resets the
  scroll/scale gesture state (same set as `touchEndEvent`) plus the touch-specific state
  (`_touchCoordinate`, `_touchCancelCrosshair`, `_touchZoomed`) and clears the crosshair.

Unlike `touchEndEvent`, the state reset is **unconditional**: on cancel there is no
meaningful "widget under the finger" semantics to gate on, and the point of the handler is
to guarantee a clean slate.

## Verification

- `pnpm code-lint` — pass (154 files, no fixes)
- `pnpm type-check` — pass
- `pnpm build-esm` — pass
- Manual: start a drag on a touch device, trigger a system cancel (e.g. notification shade
  pull) mid-gesture — afterwards the chart responds to the next touch immediately and no
  crosshair/scroll state is stuck; on `main` the same sequence leaves the gesture state
  dangling.

## Notes

- Fling inertia is not started on cancel (it only starts in `touchEndEvent`), so no change
  is needed there.
- The existing target-level `touchcancel` listener for the long-tap timeout is kept.